### PR TITLE
chore(deps): bump alpine to 3.21.2 and goose to 3.24.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17.0
+FROM alpine:3.21.2
 MAINTAINER Gomicro Dev <dev@gomicro.io>
 
 RUN apk update && \
@@ -6,7 +6,7 @@ RUN apk update && \
     apk add bash && \
     rm -rf /var/cache/apk/*
 
-ADD https://github.com/pressly/goose/releases/download/v3.7.0/goose_linux_x86_64 /bin/goose
+ADD https://github.com/pressly/goose/releases/download/v3.24.1/goose_linux_x86_64 /bin/goose
 RUN chmod +x /bin/goose
 
 WORKDIR /migrations


### PR DESCRIPTION
The newer version of goose includes support for Turso database migrations.
This update ensures compatibility with Turso while keeping the base image up to date with Alpine.

- Update alpine to 3.21.2
- Update goose to 3.24.1